### PR TITLE
Fix list items

### DIFF
--- a/lib/forkreadme/generator.rb
+++ b/lib/forkreadme/generator.rb
@@ -71,7 +71,7 @@ module ForkReadme
 
     # Private: Returns a link in Markdown format.
     def link_to text, href
-      "[#{text}] (#{href})"
+      "[#{text}](#{href})"
     end
 
     # Private: Returns an image in Markdown format.


### PR DESCRIPTION
The generated **markdown** does not display items a links, due to a space in **raw content**