### PR TITLE
Repo origin could be without protocol (in ~/.ssh/config)

### DIFF
--- a/lib/forkreadme/generator.rb
+++ b/lib/forkreadme/generator.rb
@@ -106,7 +106,7 @@ module ForkReadme
 
       clone_url = parse_url origin
 
-      if clone_url.host.downcase != "github.com"
+      if not clone_url.host.downcase.start_with?("github")
         raise NotGitHubRepo.new "Not a GitHub repo: #{path}"
       end
 
@@ -138,11 +138,19 @@ module ForkReadme
     def parse_url url
       begin
         URI.parse(url)
-  
       rescue URI::InvalidURIError
-        if m = url.match("^(#{USERINFO})@(#{HOST}):(#{REL_PATH})$")
-          URI::Generic.new "ssh", m[1], m[2], 22, nil, "/" + m[3], nil, nil, nil
-  
+        if url.start_with?('http')
+          proto, _ = url.split(":")
+        else
+          proto = "ssh"
+        end
+        if u = url.match("(#{USERINFO})@(#{HOST})")
+          user = u[1]
+        else
+          user = "git"
+        end
+        if m = url.match("(#{HOST})(:|\/)(#{REL_PATH})$")
+          URI::Generic.new proto, user, m[1], 22, nil, "/" + m[3], nil, nil, nil
         else
           raise
         end


### PR DESCRIPTION
Hi,

I found this `awesome` **gem** to _override_ my fork's readme.

However, my forks hae origin as : `github:waghanza/...` (as **github** is an **ssh alias** for me).

I have made code evolution to allow origin to be :

+ http(s)://(git@)github.com:waghanza/...
+ (git@)github.com:waghanza/...
+ (git@)github:waghanza/...

Regards,